### PR TITLE
Fix duplication in the error message sent when a nickname is already …

### DIFF
--- a/ircd/client.go
+++ b/ircd/client.go
@@ -231,7 +231,7 @@ func (client *Client) ChangeNick(nick string) {
 	}
 
 	if cli := client.server.clients.Find(nick); cli != nil {
-		client.Send(client.server.name, ERR_NICKNAMEINUSE, client.nick, fmt.Sprintf("%s is in use", nick))
+		client.Send(client.server.name, ERR_NICKNAMEINUSE, client.nick, fmt.Sprintf("%s", nick))
 		return
 	}
 


### PR DESCRIPTION
…in use. Clients (in theory) format this however they want to since this is a numeric reply.